### PR TITLE
Pipelinefix

### DIFF
--- a/Get-DNSHostEntryAsync.ps1
+++ b/Get-DNSHostEntryAsync.ps1
@@ -59,7 +59,7 @@
         }
     }
     End {
-        $Task = ForEach ($Computer in $Computername) {
+        $Task = ForEach ($Computer in $Computerlist) {
             If (([bool]($Computer -as [ipaddress]))) {
                 [pscustomobject] @{
                     Computername = $Computer                    

--- a/Test-ConnectionAsync.ps1
+++ b/Test-ConnectionAsync.ps1
@@ -171,7 +171,7 @@ Function Test-ConnectionAsync {
         }
     }
     End {
-        $Task = ForEach ($Computer in $Computername) {
+        $Task = ForEach ($Computer in $Computerlist) {
             [pscustomobject] @{
                 Computername = $Computer
                 Task = (New-Object System.Net.NetworkInformation.Ping).SendPingAsync($Computer,$Timeout, $Buffer, $PingOptions)


### PR DESCRIPTION
Hi Boe, This is my first PR so I hope it meets the requirements. The change is identical in both files and addresses the  use of $Computername instead of $Computerlist in the foreach loop in the end block. When piping in computer names this would result in only the last item in the pipeline being processed.

Regards

Robert Thomson